### PR TITLE
support aarch64

### DIFF
--- a/src/ext/libcharsetdetect/nspr-emu/prcpucfg_linux.h
+++ b/src/ext/libcharsetdetect/nspr-emu/prcpucfg_linux.h
@@ -509,6 +509,52 @@
 #define PR_BYTES_PER_WORD_LOG2   2
 #define PR_BYTES_PER_DWORD_LOG2  3
 
+#elif defined(__aarch64__)
+
+#define IS_LITTLE_ENDIAN 1
+#undef  IS_BIG_ENDIAN
+#define IS_64
+
+#define PR_BYTES_PER_BYTE   1
+#define PR_BYTES_PER_SHORT  2
+#define PR_BYTES_PER_INT    4
+#define PR_BYTES_PER_INT64  8
+#define PR_BYTES_PER_LONG   8
+#define PR_BYTES_PER_FLOAT  4
+#define PR_BYTES_PER_DOUBLE 8
+#define PR_BYTES_PER_WORD   8
+#define PR_BYTES_PER_DWORD  8
+
+#define PR_BITS_PER_BYTE    8
+#define PR_BITS_PER_SHORT   16
+#define PR_BITS_PER_INT     32
+#define PR_BITS_PER_INT64   64
+#define PR_BITS_PER_LONG    64
+#define PR_BITS_PER_FLOAT   32
+#define PR_BITS_PER_DOUBLE  64
+#define PR_BITS_PER_WORD    64
+
+#define PR_BITS_PER_BYTE_LOG2   3
+#define PR_BITS_PER_SHORT_LOG2  4
+#define PR_BITS_PER_INT_LOG2    5
+#define PR_BITS_PER_INT64_LOG2  6
+#define PR_BITS_PER_LONG_LOG2   6
+#define PR_BITS_PER_FLOAT_LOG2  5
+#define PR_BITS_PER_DOUBLE_LOG2 6
+#define PR_BITS_PER_WORD_LOG2   6
+
+#define PR_ALIGN_OF_SHORT   2
+#define PR_ALIGN_OF_INT     4
+#define PR_ALIGN_OF_LONG    8
+#define PR_ALIGN_OF_INT64   8
+#define PR_ALIGN_OF_FLOAT   4
+#define PR_ALIGN_OF_DOUBLE  8
+#define PR_ALIGN_OF_POINTER 8
+#define PR_ALIGN_OF_WORD    8
+
+#define PR_BYTES_PER_WORD_LOG2   3
+#define PR_BYTES_PER_DWORD_LOG2  3
+
 #elif defined(__hppa__)
 
 #undef  IS_LITTLE_ENDIAN


### PR DESCRIPTION
I checked py27, py34, py35 and py36 on Amlogic S905X device.

thanks [Kevin Mihelich](https://github.com/archlinuxarm/PKGBUILDs/blob/9ddecef17ef7f1682dcc17a1ecafcc0aba1fee06/community/python-cchardet/0001-Add-AArch64-support.patch) 

[dist.zip](https://github.com/PyYoshi/cChardet/files/801811/dist.zip)

```bash
$ sha256sum cchardet-1.1.2-cp*
691a31fc22d6f0dff4925221bfe31e7c6476145b0ee0a0de8244d3a518d65dff  cchardet-1.1.2-cp27-cp27mu-linux_aarch64.whl
6df93415acb03599210d740540342e15f4f3f9b76a2593786ce8d48bd0049fa3  cchardet-1.1.2-cp34-cp34m-linux_aarch64.whl
3324858a62a3ec32ba15c8b1a4232ff9d60edaf9b051394920316019140a9eb1  cchardet-1.1.2-cp35-cp35m-linux_aarch64.whl
cb1319321fed84be5a4b7e7431c392c032f260a461130a56cd2ccc673faef3bb  cchardet-1.1.2-cp36-cp36m-linux_aarch64.whl
```

---

OS: Ubuntu Mate 16.04 64bit
SoC: Amlogic S905X
RAM: 2GB
Board: X96 TV Box http://www.gearbest.com/tv-box-mini-pc/pp_471548.html

```bash
$ uname -a
Linux amlogic-s905x 3.14.29 #34 SMP PREEMPT Wed Feb 22 11:00:40 MSK 2017 aarch64 aarch64 aarch64 GNU/Linux
```

```bash
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 16.04.2 LTS
Release:	16.04
Codename:	xenial
```

```bash
$ cat /proc/cpuinfo
Processor	: AArch64 Processor rev 4 (aarch64)
processor	: 0
processor	: 1
processor	: 2
processor	: 3
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 
CPU implementer	: 0x41
CPU architecture: AArch64
CPU variant	: 0x0
CPU part	: 0xd03
CPU revision	: 4

Hardware	: Amlogic
Serial		: 210a8200ac5816f71916a7fac5ed7ab5
Revision	: 020a
```

```bash
$ cat /proc/meminfo
MemTotal:        1850444 kB
MemFree:          508400 kB
MemAvailable:    1579884 kB
Buffers:           38360 kB
Cached:           971432 kB
SwapCached:            0 kB
Active:           412492 kB
Inactive:         775976 kB
Active(anon):      14844 kB
Inactive(anon):   182392 kB
Active(file):     397648 kB
Inactive(file):   593584 kB
Unevictable:           0 kB
Mlocked:               0 kB
SwapTotal:        131068 kB
SwapFree:         131068 kB
Dirty:                 0 kB
Writeback:             0 kB
AnonPages:        178684 kB
Mapped:            33192 kB
Shmem:             18560 kB
Slab:             120804 kB
SReclaimable:     100628 kB
SUnreclaim:        20176 kB
KernelStack:        3936 kB
PageTables:         4540 kB
NFS_Unstable:          0 kB
Bounce:                0 kB
WritebackTmp:          0 kB
CommitLimit:     1056288 kB
Committed_AS:    1354200 kB
VmallocTotal:    1048576 kB
VmallocUsed:       51044 kB
VmallocChunk:     986824 kB
HugePages_Total:       0
HugePages_Free:        0
HugePages_Rsvd:        0
HugePages_Surp:        0
Hugepagesize:       2048 kB
```
