### PR TITLE
Removed py35 environment as support drops for python 3.5

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, py38, py39, py310
+envlist = py36, py37, py38, py39, py310
 
 [testenv]
 commands =


### PR DESCRIPTION
Removed py35 environment as support drops for python 3.5