### PR TITLE
Upgrade Cython for Python 3.11

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ verify_ssl = true
 chardet = "==3.0.4"
 nose = "==1.3.7"
 tox = "==3.20.1"
-Cython = "==0.29.21"
+Cython = "==0.29.30"
 pylint = "==2.6.0"
 wheel = "==0.35.1"
 twine = "==3.2.0"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 chardet==3.0.4
 nose==1.3.7
 tox==3.20.1
-Cython==0.29.21
+Cython==0.29.30
 # pylint==2.6.0
 # wheel==0.35.1
 # twine==3.2.0


### PR DESCRIPTION
A minimal subset of #78

An on-demand GitHub Action:
```
name: pip_install_cchardet
on: [pull_request, push, workflow_dispatch]
jobs:
  pip_install_cchardet:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/setup-python@v4
        with:
          python-version: 3.11
      - run: python3.11 -m pip install --upgrade cython>=0.29.30
      - run: python3.11 -m pip install cchardet  # Will succeed only if cython>=0.29.30
```